### PR TITLE
Added `meta` annotation to intellisense.lua

### DIFF
--- a/docs/intellisense.lua
+++ b/docs/intellisense.lua
@@ -25,7 +25,7 @@
 
 -- 07/06/2024
 --[[
-    - Added `---@meta _` see https://luals.github.io/wiki/annotations/#meta
+    - Added `---@meta` see https://luals.github.io/wiki/annotations/#meta
 ]]
 
 -- 12/05/2024
@@ -141,17 +141,13 @@
     - Removed server.getVehicleName
 ]]
 
----@meta _
-
 ----------------------------------------
 ---- // Intellisense
 ----------------------------------------
 -------------------------
 -- LUA LSP DIAGNOSTICS SETTINGS
 -------------------------
---- @diagnostic disable: lowercase-global
---- @diagnostic disable: missing-return
---- @diagnostic disable: duplicate-set-field
+---@meta
 
 -------------------------
 -- DEFINITIONS

--- a/docs/intellisense.lua
+++ b/docs/intellisense.lua
@@ -25,7 +25,7 @@
 
 -- 07/06/2024
 --[[
-    - Added `---@meta` see https://luals.github.io/wiki/annotations/#meta
+    - Added `---@meta _` see https://luals.github.io/wiki/annotations/#meta
 ]]
 
 -- 12/05/2024
@@ -147,7 +147,7 @@
 -------------------------
 -- LUA LSP DIAGNOSTICS SETTINGS
 -------------------------
----@meta
+---@meta _
 
 -------------------------
 -- DEFINITIONS

--- a/docs/intellisense.lua
+++ b/docs/intellisense.lua
@@ -23,6 +23,11 @@
 ----------------------------------------
 -- Last updated for game version: v1.11.0 (The Commercial Fishing Major Update)
 
+-- 07/06/2024
+--[[
+    - Added `---@meta _` see https://luals.github.io/wiki/annotations/#meta
+]]
+
 -- 12/05/2024
 --[[
     - Switched around server.setCharacterSeated and server.setSeated (server.setSeated is no longer an alias but the actual thing)
@@ -135,6 +140,8 @@
     - Fixed server.spawnVehicle docs
     - Removed server.getVehicleName
 ]]
+
+---@meta _
 
 ----------------------------------------
 ---- // Intellisense


### PR DESCRIPTION
See https://luals.github.io/wiki/annotations/#meta
The reason I noticed this is, adding a `meta` annotation hides the `lowercase-global` diagnostics for `g_savedata`, `onTick` and all other events.
